### PR TITLE
fix: add country and network to state metadata

### DIFF
--- a/identity_demia_core/examples/resolve_legacy.rs
+++ b/identity_demia_core/examples/resolve_legacy.rs
@@ -38,7 +38,8 @@ async fn main() -> anyhow::Result<()> {
   println!("  network_str():  {}   (defaulted = {})", did.network_str(), did.network_str() == DemiaDID::DEFAULT_NETWORK);
   println!("  tag():          {}", did.tag());
 
-  // The canonical string must be byte-identical to what you passed in (no silent rewrite to long form).
+  // DemiaDID::parse lowercases the input, so compare against the lowercased DID. Asserts that a
+  // short (country/network-less) DID must NOT be silently expanded into long form during parse.
   assert_eq!(did.as_str(), did_str.to_lowercase(), "DID string was rewritten during parse!");
   // Validity must pass even though country/network are absent.
   assert!(DemiaDID::is_valid(did.as_ref()), "DID failed validity check");

--- a/identity_demia_core/examples/resolve_legacy.rs
+++ b/identity_demia_core/examples/resolve_legacy.rs
@@ -1,0 +1,79 @@
+// Resolve a legacy (country/network-less) Demia DID and prove it decodes correctly.
+//
+// Usage:
+//   # offline checks only (no node needed):
+//   cargo run -p identity_demia_core --example resolve_legacy -- <did> --offline
+//
+//   # offline checks + live resolution against a node:
+//   NODE_URL=http://localhost:14265 \
+//   cargo run -p identity_demia_core --example resolve_legacy -- <did>
+//
+// <did> defaults to the sample legacy DID if omitted.
+
+use identity_demia_core::DemiaDID;
+use identity_demia_core::DemiaDocument;
+use identity_demia_core::IotaIdentityClientExt;
+use identity_did::DID;
+use iota_sdk::client::Client;
+
+const DEFAULT_DID: &str = "did:demia:0xbdb06b7c0ee20e293049d76f81fb74fe1caad02faec42e9cfe2641a9086d9a0a";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+  let args: Vec<String> = std::env::args().skip(1).collect();
+  let offline = args.iter().any(|a| a == "--offline");
+  let did_str = args
+    .iter()
+    .find(|a| !a.starts_with("--"))
+    .cloned()
+    .unwrap_or_else(|| DEFAULT_DID.to_string());
+
+  // ---- Level 1: offline parse / default checks (no node) ----
+  println!("Input DID:        {did_str}");
+  let did: DemiaDID = DemiaDID::parse(&did_str)?; // fails here if it doesn't decode at all
+  println!("Parsed OK.");
+  println!("  canonical str:  {}", did.as_str());
+  println!("  method:         {}", did.method());
+  println!("  country_str():  {}   (defaulted = {})", did.country_str(), did.country_str() == DemiaDID::DEFAULT_COUNTRY);
+  println!("  network_str():  {}   (defaulted = {})", did.network_str(), did.network_str() == DemiaDID::DEFAULT_NETWORK);
+  println!("  tag():          {}", did.tag());
+
+  // The canonical string must be byte-identical to what you passed in (no silent rewrite to long form).
+  assert_eq!(did.as_str(), did_str.to_lowercase(), "DID string was rewritten during parse!");
+  // Validity must pass even though country/network are absent.
+  assert!(DemiaDID::is_valid(did.as_ref()), "DID failed validity check");
+  println!("Offline checks passed: short DID decodes, defaults applied, no rewrite.\n");
+
+  if offline {
+    println!("--offline set; skipping live resolution.");
+    return Ok(());
+  }
+
+  // ---- Level 2: live resolution against the node ----
+  let node_url = std::env::var("NODE_URL").unwrap_or_else(|_| "http://localhost:14265".to_string());
+  println!("Resolving against node: {node_url}");
+  let client: Client = Client::builder().with_primary_node(&node_url, None)?.finish().await?;
+
+  let document: DemiaDocument = match client.resolve_did(&did).await {
+    Ok(doc) => doc,
+    Err(e) => {
+      eprintln!("resolve_did failed: {e}");
+      eprintln!("Retrying WITHOUT the network-name guard (direct Alias Output fetch)...\n");
+      // Bypass validate_network: fetch the Alias Output by tag and unpack against the
+      // original (short) DID. This proves whether the data is actually on-chain,
+      // independent of the dmia/smr network-name check.
+      use identity_demia_core::block::output::AliasId;
+      use identity_demia_core::IotaIdentityClient;
+      let alias_id = AliasId::from(&did);
+      let (_, alias_output) = client.get_alias_output(alias_id).await?;
+      DemiaDocument::unpack_from_output(&did, &alias_output, true)?
+    }
+  };
+  println!("Resolved document id: {}", document.id());
+  // The resolved document id should keep the short form you asked for.
+  assert_eq!(document.id().as_str(), did.as_str(), "resolved document id changed form!");
+  println!("Resolution OK, document id preserved its short form.\n");
+  println!("{document:#}");
+
+  Ok(())
+}

--- a/identity_demia_core/src/client/identity_client.rs
+++ b/identity_demia_core/src/client/identity_client.rs
@@ -204,6 +204,12 @@ pub(super) async fn validate_network<T>(client: &T, did: &DemiaDID) -> Result<()
 where
   T: IotaIdentityClient + ?Sized,
 {
+  // Legacy (unscoped) DIDs carry no explicit network segment; `network_str()` returns a default
+  // that says nothing about the network the alias actually lives on. Enforcing it here would reject
+  // legacy DIDs on any network whose HRP differs from the default. Resolve them by tag instead.
+  if !did.has_explicit_scope() {
+    return Ok(());
+  }
   let network_hrp: String = client
     .get_protocol_parameters()
     .await

--- a/identity_demia_core/src/client/identity_client.rs
+++ b/identity_demia_core/src/client/identity_client.rs
@@ -204,9 +204,7 @@ pub(super) async fn validate_network<T>(client: &T, did: &DemiaDID) -> Result<()
 where
   T: IotaIdentityClient + ?Sized,
 {
-  // Legacy (unscoped) DIDs carry no explicit network segment; `network_str()` returns a default
-  // that says nothing about the network the alias actually lives on. Enforcing it here would reject
-  // legacy DIDs on any network whose HRP differs from the default. Resolve them by tag instead.
+  // Legacy (unscoped) DIDs carry no explicit network segment; Resolve them by tag instead.
   if !did.has_explicit_scope() {
     return Ok(());
   }

--- a/identity_demia_core/src/did/demia_did.rs
+++ b/identity_demia_core/src/did/demia_did.rs
@@ -189,9 +189,7 @@ impl DemiaDID {
   /// Returns `true` if the `DID` carries explicit `country:network` scope segments,
   /// i.e. it is in the long form `did:demia:<country>:<network>:<tag>`.
   ///
-  /// A legacy short DID (`did:demia:<tag>`) returns `false`; its [`country_str`](Self::country_str)
-  /// and [`network_str`](Self::network_str) are *defaulted*, not explicit. This distinction lets
-  /// callers avoid treating a defaulted scope as if it had been published on-chain.
+  /// A legacy short DID (`did:demia:<tag>`) returns `false`;
   pub fn has_explicit_scope(&self) -> bool {
     // `denormalized_components` only splits country/network out when the method id contains a ':'.
     self.method_id().contains(':')

--- a/identity_demia_core/src/did/demia_did.rs
+++ b/identity_demia_core/src/did/demia_did.rs
@@ -81,7 +81,10 @@ impl DemiaDID {
   /// # use isocountry::CountryCode;
   /// #
   /// let did = DemiaDID::new(&[1;32], &CountryCode::USA, &NetworkName::try_from("dmia").unwrap());
-  /// assert_eq!(did.as_str(), "did:demia:0x0101010101010101010101010101010101010101010101010101010101010101");
+  /// assert_eq!(
+  ///   did.as_str(),
+  ///   "did:demia:usa:dmia:0x0101010101010101010101010101010101010101010101010101010101010101"
+  /// );
   pub fn new(bytes: &[u8; 32], country_code: &CountryCode, network_name: &NetworkName) -> Self {
     let tag = prefix_hex::encode(bytes);
     let did: String = format!(
@@ -119,7 +122,10 @@ impl DemiaDID {
   /// # use isocountry::CountryCode;
   /// #
   /// let placeholder = DemiaDID::placeholder(&CountryCode::USA, &NetworkName::try_from("dmia").unwrap());
-  /// assert_eq!(placeholder.as_str(), "did:demia:0x0000000000000000000000000000000000000000000000000000000000000000");
+  /// assert_eq!(
+  ///   placeholder.as_str(),
+  ///   "did:demia:usa:dmia:0x0000000000000000000000000000000000000000000000000000000000000000"
+  /// );
   /// assert!(placeholder.is_placeholder());
   pub fn placeholder(country_code: &CountryCode, network_name: &NetworkName) -> Self {
     Self::new(&[0; 32], country_code, network_name)
@@ -158,7 +164,7 @@ impl DemiaDID {
   pub fn try_from_core(did: CoreDID) -> Result<Self> {
     Self::check_validity(&did)?;
 
-    Ok(Self(Self::normalize(did)))
+    Ok(Self(did))
   }
 
   // ===========================================================================
@@ -252,26 +258,6 @@ impl DemiaDID {
   fn check_network<D: DID>(did: &D) -> Result<()> {
     let (_, network_name, _) = Self::denormalized_components(did.method_id());
     NetworkName::validate_network_name(network_name).map_err(|_| DIDError::Other("invalid network name"))
-  }
-
-  /// Normalizes the DID `method_id` by removing the default network segment if present.
-  ///
-  /// E.g.
-  /// - `"did:iota:main:123" -> "did:iota:123"` is normalized
-  /// - `"did:iota:dev:123" -> "did:iota:dev:123"` is unchanged
-  // TODO: Remove the lint once this bug in clippy has been fixed. Without to_owned a mutable reference will be aliased.
-  #[allow(clippy::unnecessary_to_owned)]
-  fn normalize(mut did: CoreDID) -> CoreDID {
-    let method_id = did.method_id();
-    let (_, network, tag) = Self::denormalized_components(method_id);
-    if tag.len() == method_id.len() || network != Self::DEFAULT_NETWORK {
-      did
-    } else {
-      did
-        .set_method_id(tag.to_owned())
-        .expect("normalizing a valid CoreDID should be Ok");
-      did
-    }
   }
 
   /// foo:bar -> (foo, DemiaDID::DEFAULT_NETWORK, bar)
@@ -582,13 +568,17 @@ mod tests {
 
   #[test]
   fn placeholder_produces_a_did_with_expected_string_representation() {
+    let default_country = CountryCode::for_alpha3_caseless(DemiaDID::DEFAULT_COUNTRY).unwrap();
+    let default_network = NetworkName::try_from(DemiaDID::DEFAULT_NETWORK).unwrap();
     assert_eq!(
-      DemiaDID::placeholder(
-        &CountryCode::for_alpha3_caseless(DemiaDID::DEFAULT_COUNTRY).unwrap(),
-        &NetworkName::try_from(DemiaDID::DEFAULT_NETWORK).unwrap()
+      DemiaDID::placeholder(&default_country, &default_network).as_str(),
+      format!(
+        "did:{}:{}:{}:{}",
+        DemiaDID::METHOD,
+        DemiaDID::DEFAULT_COUNTRY,
+        DemiaDID::DEFAULT_NETWORK,
+        DemiaDID::PLACEHOLDER_TAG
       )
-      .as_str(),
-      format!("did:{}:{}", DemiaDID::METHOD, DemiaDID::PLACEHOLDER_TAG)
     );
 
     for name in VALID_NETWORK_NAMES
@@ -611,7 +601,7 @@ mod tests {
   }
 
   #[test]
-  fn normalization_in_constructors() {
+  fn explicit_scope_is_preserved_by_constructors() {
     let did_with_default_network_string: String = format!(
       "did:{}:{}:{}:{}",
       DemiaDID::METHOD,
@@ -619,13 +609,21 @@ mod tests {
       DemiaDID::DEFAULT_NETWORK,
       VALID_ALIAS_ID_STR
     );
-    let expected_normalization_string_representation: String =
-      format!("did:{}:{}", DemiaDID::METHOD, VALID_ALIAS_ID_STR);
 
     assert_eq!(
-      DemiaDID::parse(did_with_default_network_string).unwrap().as_str(),
-      expected_normalization_string_representation
+      DemiaDID::parse(&did_with_default_network_string).unwrap().as_str(),
+      did_with_default_network_string
     );
+  }
+
+  #[test]
+  fn legacy_did_keeps_its_short_representation() {
+    let legacy_did = format!("did:{}:{}", DemiaDID::METHOD, VALID_ALIAS_ID_STR);
+    let did = DemiaDID::parse(&legacy_did).unwrap();
+
+    assert_eq!(did.as_str(), legacy_did);
+    assert_eq!(did.country_str(), DemiaDID::DEFAULT_COUNTRY);
+    assert_eq!(did.network_str(), DemiaDID::DEFAULT_NETWORK);
   }
 
   #[test]

--- a/identity_demia_core/src/did/demia_did.rs
+++ b/identity_demia_core/src/did/demia_did.rs
@@ -186,6 +186,17 @@ impl DemiaDID {
     Self::denormalized_components(self.method_id()).2
   }
 
+  /// Returns `true` if the `DID` carries explicit `country:network` scope segments,
+  /// i.e. it is in the long form `did:demia:<country>:<network>:<tag>`.
+  ///
+  /// A legacy short DID (`did:demia:<tag>`) returns `false`; its [`country_str`](Self::country_str)
+  /// and [`network_str`](Self::network_str) are *defaulted*, not explicit. This distinction lets
+  /// callers avoid treating a defaulted scope as if it had been published on-chain.
+  pub fn has_explicit_scope(&self) -> bool {
+    // `denormalized_components` only splits country/network out when the method id contains a ':'.
+    self.method_id().contains(':')
+  }
+
   // ===========================================================================
   // Validation
   // ===========================================================================

--- a/identity_demia_core/src/document/demia_document.rs
+++ b/identity_demia_core/src/document/demia_document.rs
@@ -743,8 +743,10 @@ mod tests {
     assert_eq!(document.metadata.deactivated, Some(true));
 
     // Ensure no other fields are injected.
+    let resolved_controller_did =
+      "did:demia:usa:dmia:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let json: String = format!(
-      r#"{{"doc":{{"id":"{did}","controller":"{controller_did}"}},"meta":{{"deactivated":true,"governorAddress":"demia1pz424242424242424242424242424242424242424242424242425ryaqzy","stateControllerAddress":"demia1pz424242424242424242424242424242424242424242424242425ryaqzy"}}}}"#
+      r#"{{"doc":{{"id":"{did}","controller":"{resolved_controller_did}"}},"meta":{{"deactivated":true,"governorAddress":"dmia1pz424242424242424242424242424242424242424242424242425uk7x2y","stateControllerAddress":"dmia1pz424242424242424242424242424242424242424242424242425uk7x2y"}}}}"#
     );
     assert_eq!(document.to_json().unwrap(), json);
 

--- a/identity_demia_core/src/state_metadata/document.rs
+++ b/identity_demia_core/src/state_metadata/document.rs
@@ -33,17 +33,46 @@ pub struct StateMetadataDocument {
   pub(crate) document: CoreDocument,
   #[serde(rename = "meta")]
   pub(crate) metadata: DemiaDocumentMetadata,
+  #[serde(default, skip_serializing_if = "Option::is_none", rename = "country")]
+  pub(crate) country: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none", rename = "network")]
+  pub(crate) network: Option<String>,
 }
 
 impl StateMetadataDocument {
-  /// Transforms the document into a [`DemiaDocument`] by replacing all placeholders with `original_did`.
+  /// Transforms the document into a [`DemiaDocument`] by restoring its scoped DID in all placeholders.
   pub fn into_demia_document(self, original_did: &DemiaDID) -> Result<DemiaDocument> {
-    let Self { document, metadata } = self;
+    let Self {
+      document,
+      metadata,
+      country,
+      network,
+    } = self;
+
+    let document_did = match (country.as_deref(), network.as_deref()) {
+      (Some(country), Some(network)) => {
+        if country != original_did.country_str() {
+          return Err(Error::InvalidStateMetadata("country does not match the requested DID"));
+        }
+        if network != original_did.network_str() {
+          return Err(Error::InvalidStateMetadata("network does not match the requested DID"));
+        }
+
+        DemiaDID::parse(format!(
+          "did:{}:{country}:{network}:{}",
+          DemiaDID::METHOD,
+          original_did.tag()
+        ))
+        .map_err(|_| Error::InvalidStateMetadata("invalid country or network in state metadata"))?
+      }
+      (None, None) => original_did.clone(),
+      _ => return Err(Error::InvalidStateMetadata("country and network must both be present")),
+    };
     // Transform identifiers: Replace placeholder identifiers, and ensure that `id` and `controller` adhere to the
     // specification.
     let replace_placeholder_with_method_check = |did: CoreDID| -> Result<CoreDID> {
       if did == PLACEHOLDER_DID.as_ref() {
-        Ok(CoreDID::from(original_did.clone()))
+        Ok(CoreDID::from(document_did.clone()))
       } else {
         // TODO: Consider introducing better error variant
         DemiaDID::check_validity(&did).map_err(Error::DIDSyntaxError)?;
@@ -54,7 +83,7 @@ impl StateMetadataDocument {
     // Methods and services are not required to be IOTA UTXO DIDs, but we still want to replace placeholders
     let replace_placeholder = |did: CoreDID| -> Result<CoreDID> {
       if did == PLACEHOLDER_DID.as_ref() {
-        Ok(CoreDID::from(original_did.clone()))
+        Ok(CoreDID::from(document_did.clone()))
       } else {
         Ok(did)
       }
@@ -188,6 +217,8 @@ impl From<DemiaDocument> for StateMetadataDocument {
   /// occurrences of its did with a placeholder.
   fn from(document: DemiaDocument) -> Self {
     let id: DemiaDID = document.id().clone();
+    let country = Some(id.country_str().to_owned());
+    let network = Some(id.network_str().to_owned());
     let DemiaDocument { document, metadata } = document;
 
     // Replace self-referential identifiers with a placeholder, but not others.
@@ -204,6 +235,8 @@ impl From<DemiaDocument> for StateMetadataDocument {
     StateMetadataDocument {
       document: document.map_unchecked(id_update, controller_update, methods_update, service_update),
       metadata,
+      country,
+      network,
     }
   }
 }
@@ -235,9 +268,9 @@ mod tests {
 
   fn test_document() -> TestSetup {
     let did_self =
-      DemiaDID::parse("did:demia:0x8036235b6b5939435a45d68bcea7890eef399209a669c8c263fac7f5089b2ec6").unwrap();
+      DemiaDID::parse("did:demia:usa:dmia:0x8036235b6b5939435a45d68bcea7890eef399209a669c8c263fac7f5089b2ec6").unwrap();
     let did_foreign =
-      DemiaDID::parse("did:demia:0x71b709dff439f1ac9dd2b9c2e28db0807156b378e13bfa3605ce665aa0d0fdca").unwrap();
+      DemiaDID::parse("did:demia:usa:dmia:0x71b709dff439f1ac9dd2b9c2e28db0807156b378e13bfa3605ce665aa0d0fdca").unwrap();
 
     let mut document: DemiaDocument = DemiaDocument::new_with_id(did_self.clone());
     document
@@ -299,6 +332,8 @@ mod tests {
     } = test_document();
 
     let state_metadata_doc: StateMetadataDocument = StateMetadataDocument::from(document.clone());
+    assert_eq!(state_metadata_doc.country.as_deref(), Some(did_self.country_str()));
+    assert_eq!(state_metadata_doc.network.as_deref(), Some(did_self.network_str()));
 
     assert_eq!(
       state_metadata_doc
@@ -356,6 +391,42 @@ mod tests {
   }
 
   #[test]
+  fn scope_must_match_the_requested_did() {
+    let TestSetup { document, did_self, .. } = test_document();
+    let state_metadata_doc = StateMetadataDocument::from(document);
+
+    let wrong_country =
+      DemiaDID::parse(format!("did:demia:can:{}:{}", did_self.network_str(), did_self.tag())).unwrap();
+    assert!(state_metadata_doc.clone().into_demia_document(&wrong_country).is_err());
+
+    let wrong_network =
+      DemiaDID::parse(format!("did:demia:{}:test:{}", did_self.country_str(), did_self.tag())).unwrap();
+    assert!(state_metadata_doc.into_demia_document(&wrong_network).is_err());
+  }
+
+  #[test]
+  fn legacy_metadata_without_scope_remains_resolvable() {
+    let TestSetup { document, did_self, .. } = test_document();
+    let mut state_metadata_doc = StateMetadataDocument::from(document);
+    state_metadata_doc.country = None;
+    state_metadata_doc.network = None;
+    let legacy_did = DemiaDID::parse(format!("did:demia:{}", did_self.tag())).unwrap();
+
+    let document = state_metadata_doc.into_demia_document(&legacy_did).unwrap();
+    assert_eq!(document.id(), &legacy_did);
+  }
+
+  #[test]
+  fn scoped_metadata_restores_the_explicit_did() {
+    let TestSetup { document, did_self, .. } = test_document();
+    let state_metadata_doc = StateMetadataDocument::from(document);
+    let legacy_did = DemiaDID::parse(format!("did:demia:{}", did_self.tag())).unwrap();
+
+    let document = state_metadata_doc.into_demia_document(&legacy_did).unwrap();
+    assert_eq!(document.id(), &did_self);
+  }
+
+  #[test]
   fn test_packing_roundtrip() {
     let TestSetup { document, .. } = test_document();
 
@@ -370,6 +441,8 @@ mod tests {
       state_metadata_doc.metadata.deactivated,
       unpacked_doc.metadata.deactivated
     );
+    assert_eq!(state_metadata_doc.country, unpacked_doc.country);
+    assert_eq!(state_metadata_doc.network, unpacked_doc.network);
 
     assert_eq!(state_metadata_doc.document.id(), unpacked_doc.document.id());
     assert_eq!(
@@ -414,8 +487,11 @@ mod tests {
     state_metadata_doc.metadata.governor_address = None;
     state_metadata_doc.metadata.state_controller_address = None;
     let expected_payload: String = format!(
-      "{{\"doc\":{},\"meta\":{}}}",
-      state_metadata_doc.document, state_metadata_doc.metadata
+      "{{\"doc\":{},\"meta\":{},\"country\":\"{}\",\"network\":\"{}\"}}",
+      state_metadata_doc.document,
+      state_metadata_doc.metadata,
+      state_metadata_doc.country.as_deref().unwrap(),
+      state_metadata_doc.network.as_deref().unwrap()
     );
 
     // DID marker.

--- a/identity_demia_core/src/state_metadata/document.rs
+++ b/identity_demia_core/src/state_metadata/document.rs
@@ -33,9 +33,9 @@ pub struct StateMetadataDocument {
   pub(crate) document: CoreDocument,
   #[serde(rename = "meta")]
   pub(crate) metadata: DemiaDocumentMetadata,
-  #[serde(default, skip_serializing_if = "Option::is_none", rename = "country")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub(crate) country: Option<String>,
-  #[serde(default, skip_serializing_if = "Option::is_none", rename = "network")]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub(crate) network: Option<String>,
 }
 

--- a/identity_demia_core/src/state_metadata/document.rs
+++ b/identity_demia_core/src/state_metadata/document.rs
@@ -52,9 +52,7 @@ impl StateMetadataDocument {
     let document_did = match (country.as_deref(), network.as_deref()) {
       (Some(country), Some(network)) => {
         // A scoped requester must match the on-chain scope exactly. An unscoped (legacy short) DID
-        // makes no scope assertion, so it adopts whatever scope the alias currently carries — this
-        // lets a legacy short DID keep resolving after the identity is promoted to ANY country, not
-        // just the network default.
+        // makes no scope assertion, so it adopts whatever scope the alias currently carries
         if original_did.has_explicit_scope() {
           if country != original_did.country_str() {
             return Err(Error::InvalidStateMetadata("country does not match the requested DID"));
@@ -223,9 +221,7 @@ impl From<DemiaDocument> for StateMetadataDocument {
   /// occurrences of its did with a placeholder.
   fn from(document: DemiaDocument) -> Self {
     let id: DemiaDID = document.id().clone();
-    // Only persist scope when the DID carries it explicitly. A legacy short DID reports *defaulted*
-    // country/network via its accessors; writing those into the state metadata would silently
-    // promote the document to the long form on the next resolution. Leave legacy docs unscoped.
+    // Only persist scope when the DID carries it explicitly. Leave legacy docs unscoped.
     let (country, network) = if id.has_explicit_scope() {
       (Some(id.country_str().to_owned()), Some(id.network_str().to_owned()))
     } else {

--- a/identity_demia_core/src/state_metadata/document.rs
+++ b/identity_demia_core/src/state_metadata/document.rs
@@ -51,11 +51,17 @@ impl StateMetadataDocument {
 
     let document_did = match (country.as_deref(), network.as_deref()) {
       (Some(country), Some(network)) => {
-        if country != original_did.country_str() {
-          return Err(Error::InvalidStateMetadata("country does not match the requested DID"));
-        }
-        if network != original_did.network_str() {
-          return Err(Error::InvalidStateMetadata("network does not match the requested DID"));
+        // A scoped requester must match the on-chain scope exactly. An unscoped (legacy short) DID
+        // makes no scope assertion, so it adopts whatever scope the alias currently carries — this
+        // lets a legacy short DID keep resolving after the identity is promoted to ANY country, not
+        // just the network default.
+        if original_did.has_explicit_scope() {
+          if country != original_did.country_str() {
+            return Err(Error::InvalidStateMetadata("country does not match the requested DID"));
+          }
+          if network != original_did.network_str() {
+            return Err(Error::InvalidStateMetadata("network does not match the requested DID"));
+          }
         }
 
         DemiaDID::parse(format!(
@@ -217,8 +223,14 @@ impl From<DemiaDocument> for StateMetadataDocument {
   /// occurrences of its did with a placeholder.
   fn from(document: DemiaDocument) -> Self {
     let id: DemiaDID = document.id().clone();
-    let country = Some(id.country_str().to_owned());
-    let network = Some(id.network_str().to_owned());
+    // Only persist scope when the DID carries it explicitly. A legacy short DID reports *defaulted*
+    // country/network via its accessors; writing those into the state metadata would silently
+    // promote the document to the long form on the next resolution. Leave legacy docs unscoped.
+    let (country, network) = if id.has_explicit_scope() {
+      (Some(id.country_str().to_owned()), Some(id.network_str().to_owned()))
+    } else {
+      (None, None)
+    };
     let DemiaDocument { document, metadata } = document;
 
     // Replace self-referential identifiers with a placeholder, but not others.
@@ -405,6 +417,22 @@ mod tests {
   }
 
   #[test]
+  fn legacy_did_adopts_non_default_promoted_scope() {
+    // The alias has been promoted to a non-default country. A legacy short DID (no scope assertion)
+    // must still resolve, adopting the promoted scope rather than being rejected for a country
+    // mismatch against the default. A *scoped* mismatch is still rejected (see above).
+    let TestSetup { document, did_self, .. } = test_document();
+    let mut state_metadata_doc = StateMetadataDocument::from(document);
+    state_metadata_doc.country = Some("can".to_string());
+
+    let legacy_did = DemiaDID::parse(format!("did:demia:{}", did_self.tag())).unwrap();
+    let resolved = state_metadata_doc.into_demia_document(&legacy_did).unwrap();
+    assert!(resolved.id().has_explicit_scope());
+    assert_eq!(resolved.id().country_str(), "can");
+    assert_eq!(resolved.id().tag(), did_self.tag());
+  }
+
+  #[test]
   fn legacy_metadata_without_scope_remains_resolvable() {
     let TestSetup { document, did_self, .. } = test_document();
     let mut state_metadata_doc = StateMetadataDocument::from(document);
@@ -424,6 +452,26 @@ mod tests {
 
     let document = state_metadata_doc.into_demia_document(&legacy_did).unwrap();
     assert_eq!(document.id(), &did_self);
+  }
+
+  #[test]
+  fn legacy_source_document_stays_unscoped() {
+    // A document whose DID is the legacy short form must NOT gain country/network scope when
+    // converted to state metadata, otherwise an ordinary update would silently promote it to the
+    // long form on the next resolution.
+    let legacy_did =
+      DemiaDID::parse("did:demia:0x8036235b6b5939435a45d68bcea7890eef399209a669c8c263fac7f5089b2ec6").unwrap();
+    assert!(!legacy_did.has_explicit_scope());
+
+    let document = DemiaDocument::new_with_id(legacy_did.clone());
+    let state_metadata_doc = StateMetadataDocument::from(document);
+    assert_eq!(state_metadata_doc.country, None);
+    assert_eq!(state_metadata_doc.network, None);
+
+    // Round-tripping keeps the short form (no promotion).
+    let restored = state_metadata_doc.into_demia_document(&legacy_did).unwrap();
+    assert_eq!(restored.id(), &legacy_did);
+    assert!(!restored.id().has_explicit_scope());
   }
 
   #[test]


### PR DESCRIPTION
## Summary
Updates to include country code and network id in document state metadata. This is parsed from the did strings in the  `into_document()` function.   